### PR TITLE
Move to .withAllGrammars

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
             packages.myVimPackage = with vimPlugins; {
               start = pluginMapper startPlugins ++ [
                 # TODO put this into overlay / config.nix
-                (nvim-treesitter.withPlugins (plugins: tree-sitter.allGrammars))
+                nvim-treesitter.withAllGrammars
               ];
               opt = pluginMapper optPlugins;
             };


### PR DESCRIPTION
I encounterd problems with treesitter parsers when using `nvim-treesitter.withPlugins (plugins: tree-sitter.allGrammars`.

You can check if parsers may have errors by executing: `:checkhealth nvim-treesitter`.
There was at the bottom a few errors including bash highlighting which lead to lua errors in every bash file.
The problem only occures when using `nixpkgs-unstable`.

The solution is to use ` nvim-treesitter.withAllGrammars` which is using the grammars in the treesitter lockfile.
Source: https://discourse.nixos.org/t/psa-if-you-are-on-unstable-try-out-nvim-treesitter-withallgrammars/23321